### PR TITLE
Make it an option to read file in either direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "sagitta"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sagitta"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "sagitta"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sagitta"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0.68"
 chrono = "0.4.23"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sagitta
 
+> :warning: This is a test project as part of me learning Rust. Don't expect it to be perfect!
+
 A Rust CLI tool for retrieving job information from SGE accounting files.
 
 ## Setup
@@ -25,7 +27,7 @@ You can use `sagitta` to return job information from the SGE accounting file by 
 
 ```bash
 $ sagitta --help
-Usage: sagitta [-j|--job-id=JOB_ID] FILE
+Usage: sagitta [-j|--job-id=JOB_ID] [-f|--forward] FILE
 ```
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow;
 use rev_buf_reader::RevBufReader;
-use std::io::BufRead;
+use std::io::{BufRead, BufReader};
 use std::{fmt, fs::File, io, path::Path};
 
 use chrono::NaiveDateTime;
@@ -285,6 +285,14 @@ where
 {
     let file = File::open(filename)?;
     Ok(RevBufReader::new(file))
+}
+
+pub fn read_file<P>(filename: P) -> io::Result<BufReader<File>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(BufReader::new(file))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ mod tests {
 
         assert_eq!(
             Some(right_line.to_string()),
-            find_line(file_string, 66).unwrap()
+            find_line(read_file(file_string).unwrap(), 66)
         );
     }
 
@@ -322,6 +322,6 @@ mod tests {
 
         let file_string = String::from(file.path().to_str().unwrap());
 
-        assert_eq!(None, find_line(file_string, 66).unwrap());
+        assert_eq!(None, find_line(read_file_rev(file_string).unwrap(), 66));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,14 +60,13 @@ impl Seeker {
 ///
 /// assert_eq!(Some(line.to_string()), find_line(file_path, 2).unwrap());
 /// ```
-pub fn find_line(f: String, id: i32) -> Result<Option<String>, anyhow::Error> {
-    let open_file = read_file(&f)?;
-
-    let line: Option<String> = open_file
+pub fn find_line<F: BufRead>(open_file: F, id: i32) -> Result<String, anyhow::Error> {
+    let line: String = open_file
         .lines()
         .map(|l| l.unwrap())
-        .filter(|x| !x.starts_with("#"))
-        .find(|x| x.split(":").nth(5).unwrap().parse::<i32>().unwrap().eq(&id));
+        .filter(|x| !x.starts_with('#'))
+        .find(|x| x.split(':').nth(5).unwrap().parse::<i32>().unwrap().eq(&id))
+        .unwrap();
 
     Ok(line)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,20 @@ impl Seeker {
         self
     }
 
-    pub fn run(&self) -> Result<String, anyhow::Error> {
+    pub fn run(&self) -> Option<String> {
         let file = self.file.clone();
         let id = self.id;
         let forward = self.forward;
 
-        if forward {
-            let open_file = read_file(&file)?;
+        let line = if forward {
+            let open_file = read_file(&file).ok()?;
             find_line(open_file, id)
         } else {
-            let open_file = read_file_rev(&file)?;
+            let open_file = read_file_rev(&file).ok()?;
             find_line(open_file, id)
-        }
+        };
+
+        line
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl JobInfo {
 ///
 /// taken from https://doc.rust-lang.org/rust-by-example/std_misc/file/read_lines.html
 ///
-pub fn read_file<P>(filename: P) -> io::Result<RevBufReader<File>>
+pub fn read_file_rev<P>(filename: P) -> io::Result<RevBufReader<File>>
 where
     P: AsRef<Path>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,25 +50,23 @@ impl Seeker {
 /// ```rust
 /// use std::io::Write;
 /// use tempfile::NamedTempFile;
-/// use sagitta::{find_line};
+/// use sagitta::{find_line, read_file};
 ///
 /// let mut file = NamedTempFile::new().unwrap();
 /// writeln!(file, "test:one:big:thing:mem:1:20\ntest:two:job:thing:mem:2:100\ntest:three:job:thing:mem:3:234").unwrap();
 ///
 /// let line = "test:two:job:thing:mem:2:100";
 /// let file_path = String::from(file.path().to_str().unwrap());
+/// let open_file = read_file(file_path).unwrap();
 ///
-/// assert_eq!(Some(line.to_string()), find_line(file_path, 2).unwrap());
+/// assert_eq!(Some(line.to_string()), find_line(open_file, 2));
 /// ```
-pub fn find_line<F: BufRead>(open_file: F, id: i32) -> Result<String, anyhow::Error> {
-    let line: String = open_file
+pub fn find_line<F: BufRead>(open_file: F, id: i32) -> Option<String> {
+    open_file
         .lines()
         .map(|l| l.unwrap())
         .filter(|x| !x.starts_with('#'))
         .find(|x| x.split(':').nth(5).unwrap().parse::<i32>().unwrap().eq(&id))
-        .unwrap();
-
-    Ok(line)
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow;
 use rev_buf_reader::RevBufReader;
 use std::io::{BufRead, BufReader};
 use std::{fmt, fs::File, io, path::Path};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,42 @@ use std::{fmt, fs::File, io, path::Path};
 
 use chrono::NaiveDateTime;
 
+pub struct Seeker {
+    file: String,
+    id: i32,
+    // to search forward or backward through file
+    forward: bool,
+}
+
+impl Seeker {
+    pub fn new(file: String, id: i32) -> Self {
+        Seeker {
+            file,
+            id,
+            forward: false,
+        }
+    }
+
+    pub fn forward(&mut self, arg: bool) -> &mut Self {
+        self.forward = arg;
+        self
+    }
+
+    pub fn run(&self) -> Result<String, anyhow::Error> {
+        let file = self.file.clone();
+        let id = self.id;
+        let forward = self.forward;
+
+        if forward {
+            let open_file = read_file(&file)?;
+            find_line(open_file, id)
+        } else {
+            let open_file = read_file_rev(&file)?;
+            find_line(open_file, id)
+        }
+    }
+}
+
 /// Finds a line based on ID column within file
 ///
 /// SGE accounting files as colon separated with the job ID as the 5th item

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,13 @@ fn parse_args() -> Result<Args, lexopt::Error> {
 fn main() -> Result<(), anyhow::Error> {
     let args = parse_args()?;
 
-    let line = Seeker::new(args.file, args.job_id)
+    let line: Option<String> = Seeker::new(args.file, args.job_id)
         .forward(args.forward)
-        .run()?;
+        .run();
 
-    if line.len() > 0 {
-        println!("{}", JobInfo::new(line.split(':').collect::<Vec<&str>>()))
-    } else {
-        println!("No job with ID {}", args.job_id)
+    match line {
+        Some(line) => println!("{}", JobInfo::new(line.split(':').collect::<Vec<&str>>())),
+        _ => println!("No job with ID {}", args.job_id),
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn parse_args() -> Result<Args, lexopt::Error> {
             }
             Short('f') | Long("forward") => forward = true,
             Long("help") => {
-                println!("Usage: sagitta [-j|--job-id=JOB_ID] FILE");
+                println!("Usage: sagitta [-j|--job-id=JOB_ID] [-f|--forward] FILE");
                 std::process::exit(0);
             }
             _ => return Err(arg.unexpected()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
-use sagitta::{find_line, JobInfo};
+use sagitta::{JobInfo, Seeker};
 
 struct Args {
     file: String,
     job_id: i32,
+    forward: bool,
 }
 
 fn parse_args() -> Result<Args, lexopt::Error> {
@@ -11,6 +12,7 @@ fn parse_args() -> Result<Args, lexopt::Error> {
     let mut file = None;
     let mut job_id = 1;
     let mut parser = lexopt::Parser::from_env();
+    let mut forward = false;
     while let Some(arg) = parser.next()? {
         match arg {
             Short('j') | Long("job-id") => {
@@ -19,6 +21,7 @@ fn parse_args() -> Result<Args, lexopt::Error> {
             Value(val) if file.is_none() => {
                 file = Some(val.into_string()?);
             }
+            Short('f') | Long("forward") => forward = true,
             Long("help") => {
                 println!("Usage: sagitta [-j|--job-id=JOB_ID] FILE");
                 std::process::exit(0);
@@ -30,17 +33,21 @@ fn parse_args() -> Result<Args, lexopt::Error> {
     Ok(Args {
         file: file.ok_or("missing argument FILE")?,
         job_id,
+        forward,
     })
 }
 
 fn main() -> Result<(), anyhow::Error> {
     let args = parse_args()?;
 
-    let line = find_line(args.file, args.job_id)?;
+    let line = Seeker::new(args.file, args.job_id)
+        .forward(args.forward)
+        .run()?;
 
-    match line {
-        Some(line) => println!("{}", JobInfo::new(line.split(":").collect::<Vec<&str>>())),
-        _ => println!("No job with ID {}", args.job_id),
+    if line.len() > 0 {
+        println!("{}", JobInfo::new(line.split(':').collect::<Vec<&str>>()))
+    } else {
+        println!("No job with ID {}", args.job_id)
     }
 
     Ok(())


### PR DESCRIPTION
This PR adds functionality to specify whether you want to read the file from top or bottom. 

It adds a new `-f` or `--forward` option that allows the user to specify reading the file from the top rather than the bottom (the default behaviour).

Addresses #6 